### PR TITLE
Send TESTINFO with 'key=value' response, and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,21 @@
-# EUT Controller TCP server
-[RadiMation](https://www.raditeq.com/automated-emc-software/) is an EMC test automation software. RadiMation has the possibility to exchange test information
-and status with an EUT using an EUT controller device driver. This EUT controller device driver can for example be used to inform the EUT of the actually tested frequency
-and when the dwell time is started and stopped.
+# EUT Controller TCP/IP server
+[RadiMation](https://www.raditeq.com/automated-emc-software/) is an EMC test automation software. RadiMation has the possibility to exchange test 
+and status information with an Equipment Under Test (EUT) using an EUT controller device driver. This EUT controller device driver can for example 
+be used to inform the EUT of the actually tested frequency and when the dwell time is started and stopped.
 
 One of the available EUT controller device drivers is the '[Raditeq EUT Status Controller](https://wiki.radimation.com/wiki/index.php/Raditeq_EUT_Status_Controller)'. That device driver
 can be configured to use any communication medium to communicate generic events to an EUT or a third party software (which can communicate it to the EUT through a proprietary protocol).
 
-The third party software should create a TCP/IP server to listen on TCPIP port 58426. The 'Raditeq EUT Status Controller' device driver will then connect to the server, and will communicate
+The third party software should create a TCP/IP server to listen on TCP/IP port 58426. The 'Raditeq EUT Status Controller' device driver will then connect to the server, and will communicate
 the actual test status. The configuration in RadiMation can be set to use 'tcpip://localhost:58426' as the address.
 
 ![](Images/DeviceDriverConfiguration.png)
 
 This Python script provides an example, on how this TCP/IP server can be implemented.
 The RadiMation driver will send EUT information and Test information items to this Python EUT Controller server. Additionally it is possible to update test information items in the test data.
+
+The exact details of the communication between RadiMation and the TCP/IP server are described on the [Raditeq EUT Status Controller page](https://wiki.radimation.com/wiki/index.php/Raditeq_EUT_Status_Controller)
+on the [RadiWiki website](https://wiki.radimation.com/wiki/index.php/Main_Page).
 
 ## Receiving EUT information items
 At the start of the test the RadiMation EUT Status Controller driver will send all known EUT information items to the TCP/IP server.
@@ -32,7 +35,7 @@ Which key-value pairs are transmitted is completely depending on the information
 The EUT Status Controller driver will also send a request "TESTINFO?" to the server, which is then able to respond with a 'key' and 'value' which will be update or
 create a new information item in the general test information of the performed test.
 
-The format to send information back is: <key>=<value>
+The format to send information back is: TESTINFO <key>=<value>
 
 Every key-value pair that is provided, will be updated or added on the 'General Info' window in the test data window of RadiMation. A few specific keys with specific names
 have some additional effect.
@@ -54,3 +57,5 @@ The example Python script can be used as a starting point to further automate th
 * Forward the actually tested frequency to the EUT monitoring software
 * Perform an EUT validation sequence during every dwell time of a test
 * Update the actual test parameters as On Screen Display (OSD) text on a monitor.
+* Retrieve the actual operating mode of the EUT, and update it in the test results
+* Retrieve and log the name of the test engineer that is executing the test

--- a/eut_controller_server.py
+++ b/eut_controller_server.py
@@ -77,7 +77,7 @@ class TCPServer:
             if "TESTINFO?" in data:
                 # send the response back for the TESTINFO? request
                 for key, value in responses.items():
-                    response = f"{key}={value}"
+                    response = f"TESTINFO {key}={value}"
                     print(f"Sending data: {response}")
                     conn.send((response + '\n').encode())
             # Read new data
@@ -116,7 +116,7 @@ if __name__ == '__main__':
     server_thread.start()
     
     try:
-        input("Press [Enter] to close.")
+        input("\nPress [Enter] to close.\n\n")
     except KeyboardInterrupt:
         pass
     except Exception:


### PR DESCRIPTION
Include the TESTINFO command as part of each 'key=value' line. 
Additional documentation improvements.
Clearer message for 'Press [Enter] to close.' on a separate line.